### PR TITLE
Prevent self (mc.thePlayer) from being removed by hideNonNPCs config

### DIFF
--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -865,7 +865,7 @@ public class HytilsConfig extends Vigilant {
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Non-NPCs in SkyBlock",
-        description = "Remove entities that are not NPCs in SkyBlock.",
+        description = "Remove all entities (besides yourself) that are not NPCs in SkyBlock.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideNonNPCs;

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -865,7 +865,7 @@ public class HytilsConfig extends Vigilant {
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Non-NPCs in SkyBlock",
-        description = "Remove all entities (besides yourself) that are not NPCs in SkyBlock.",
+        description = "Remove all entities that are not NPCs (including all players besides yourself) in SkyBlock.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideNonNPCs;

--- a/src/main/java/cc/woverflow/hytils/handlers/lobby/npc/NPCHandler.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/lobby/npc/NPCHandler.java
@@ -25,6 +25,7 @@ import net.minecraft.client.network.NetworkPlayerInfo;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import cc.woverflow.hytils.HytilsReborn;
@@ -47,7 +48,7 @@ public class NPCHandler {
             if (HytilsConfig.npcHider && HytilsReborn.INSTANCE.getLobbyChecker().playerIsInLobby()) {
                 event.setCanceled(true);
             }
-        } else if (HytilsConfig.hideNonNPCs && locraw != null && locraw.getGameType() == GameType.SKYBLOCK && !(event.entity instanceof EntityArmorStand && !event.entity.getCustomNameTag().toLowerCase().trim().isEmpty())) {
+        } else if (HytilsConfig.hideNonNPCs && locraw != null && locraw.getGameType() == GameType.SKYBLOCK && !(event.entity instanceof EntityArmorStand && !event.entity.getCustomNameTag().toLowerCase().trim().isEmpty()) && event.entity instanceof EntityOtherPlayerMP) {
             event.setCanceled(true);
         }
     }


### PR DESCRIPTION
## Description
Added extra check to ensure that mc.thePlayer is not affected by HytilsConfig.hideNonNPCs

## Related Issue(s)
N/A
Fixes # [N/A]
